### PR TITLE
Add option to disable statusline hiding in cmd mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ var options = {
         enable: true,   # 'false' will disable command completion
         pum: true,      # 'false' for flat menu, 'true' for stacked menu
         fuzzy: false,   # fuzzy completion
+        hidestatusline: false, # (experimental) hide statusline when 'pum' is 'false'
     }
 }
 ```

--- a/autoload/cmd.vim
+++ b/autoload/cmd.vim
@@ -158,11 +158,13 @@ var ruler: bool
 def Init()
     PopupCreate()
     CmdlineEnable()
-    statusline = &statusline
-    showmode = &showmode
-    ruler = &ruler
-    :set noshowmode noruler
-    :set statusline=%<
+	if options.hidestatusline
+    	statusline = &statusline
+    	showmode = &showmode
+    	ruler = &ruler
+    	:set noshowmode noruler
+    	:set statusline=%<
+	endif
 enddef
 
 def Clear()
@@ -171,13 +173,15 @@ def Clear()
     :redraw
     ##
     popup_winid->popup_close()
-    if showmode
-	:set showmode
-    endif
-    if ruler
-	:set ruler
-    endif
-    exec $'set statusline={statusline}'
+	if options.hidestatusline
+		if showmode
+		:set showmode
+		endif
+		if ruler
+		:set ruler
+		endif
+		exec $'set statusline={statusline}'
+	endif
 enddef
 
 def Complete()


### PR DESCRIPTION
The feature of hiding the statusline breaks my statusline setup which is very dynamic.

This PR adds the same option to the cmd mode as already present for search mode.

Note: Changing this config flag between `Init()` and `Clear()` might have strange effects. But I think this is a rare edge case. 